### PR TITLE
resolved page flickering - wait for page to fully load

### DIFF
--- a/content-scripts/index.ts
+++ b/content-scripts/index.ts
@@ -156,6 +156,18 @@ const init = async (): Promise<void> => {
     // TODO (luisd): make a better mechanism for functions that depend on previous
     // steps and might be async
     await rememberLogin(data);
+    await new Promise<void>((resolve) => {
+        if (document.readyState === "complete") {
+            document.getElementsByTagName("html")[0].style.display = "block";
+            resolve();
+        } else {
+            window.addEventListener("load", () => {
+                document.getElementsByTagName("html")[0].style.display =
+                    "block";
+                resolve();
+            });
+        }
+    });
 };
 
 init();

--- a/css/loadPage.css
+++ b/css/loadPage.css
@@ -1,0 +1,3 @@
+html {
+    display: none;
+}

--- a/manifest/base.json
+++ b/manifest/base.json
@@ -19,6 +19,7 @@
             "run_at": "document_start",
             "matches": ["https://sigarra.up.pt/feup/*"],
             "css": [
+                "css/loadPage.css",
                 "css/components.css",
                 "css/simpler.css",
                 "css/custom.css",


### PR DESCRIPTION
Closes #172 
- Set a timeout probably does not always work depending on how good your connection is
- Tried to enforce waiting for all the previous work to be done before displaying the page. Didn't solve the problem; which probably meant that with the timeout, we were giving time to the page itself to finish loading something
- Now , explicitly saying : if the page is done loading show it ; if not addEventListener when "load" fires (the page is finished loading) now you can show it
